### PR TITLE
Revert "linker: Reset the active shim libs each time we do a dlopen"

### DIFF
--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -896,16 +896,11 @@ static std::vector<std::string> g_ld_all_shim_libs;
 
 static linked_list_t<const std::string> g_active_shim_libs;
 
-static void reset_g_active_shim_libs(void) {
-  g_active_shim_libs.clear();
+static void parse_LD_SHIM_LIBS(const char* path) {
+  parse_path(path, " :", &g_ld_all_shim_libs);
   for (const auto& pair : g_ld_all_shim_libs) {
     g_active_shim_libs.push_back(&pair);
   }
-}
-
-static void parse_LD_SHIM_LIBS(const char* path) {
-  parse_path(path, " :", &g_ld_all_shim_libs);
-  reset_g_active_shim_libs();
 }
 
 static bool shim_lib_matches(const char *shim_lib, const char *realpath) {
@@ -1749,7 +1744,6 @@ soinfo* do_dlopen(const char* name, int flags, const android_dlextinfo* extinfo)
   }
 
   ProtectedDataGuard guard;
-  reset_g_active_shim_libs();
   soinfo* si = find_library(name, flags, extinfo);
   if (si != nullptr) {
     si->call_constructors();


### PR DESCRIPTION
This reverts commit ad21814c21f40f0e0a4f62e03619e274de9f6983.

Change-Id: I205bcbaae6c1494601f9245fe360a088d5b745e9